### PR TITLE
PODS-8536 Change pspName to psaName. This is because the template exp…

### DIFF
--- a/app/controllers/DeclarationPspController.scala
+++ b/app/controllers/DeclarationPspController.scala
@@ -114,7 +114,7 @@ class DeclarationPspController @Inject()(val controllerComponents: MessagesContr
     val schemeAdministratorType = AdministratorOrPractitioner.Practitioner
 
     val templateParams = Map(
-      "pspName" -> pspName,
+      "psaName" -> pspName,
       "schemeName" -> schemeName,
       "taxYear" -> taxYear,
       "dateSubmitted" -> submittedDate


### PR DESCRIPTION
…ects the latter. Strictly we should change template to expect a more generic name but that takes time and we need this resolving before we go live soon