### PR TITLE
PODS-8733: New content for no data error

### DIFF
--- a/app/controllers/fileUpload/ValidationErrorsAllController.scala
+++ b/app/controllers/fileUpload/ValidationErrorsAllController.scala
@@ -45,10 +45,11 @@ class ValidationErrorsAllController @Inject()(
     implicit request =>
       val returnUrl = controllers.fileUpload.routes.FileUploadController.onPageLoad(waypoints, eventType).url
       val fileDownloadInstructionLink = controllers.routes.FileDownloadController.instructionsFile(eventType).url
+      val fileTemplateInstructionLink = controllers.routes.FileDownloadController.templateFile(eventType).url
       parsingAndValidationOutcomeCacheConnector.getOutcome.map {
         case Some(outcome@ParsingAndValidationOutcome(ValidationErrorsLessThan10, _, _)) =>
           outcome.json.validate[Seq[ValidationErrorForRendering]] match {
-            case JsSuccess(value, _) => Ok(view(returnUrl, fileDownloadInstructionLink, value))
+            case JsSuccess(value, _) => Ok(view(returnUrl, fileDownloadInstructionLink, value, fileTemplateInstructionLink))
             case JsError(errors) => throw JsResultException(errors)
           }
         case _ => NotFound

--- a/app/views/fileUpload/ValidationErrorsAllView.scala.html
+++ b/app/views/fileUpload/ValidationErrorsAllView.scala.html
@@ -23,15 +23,16 @@
         govukTable : GovukTable
 )
 
-@(returnToFileUploadURL: String, fileDownloadInstructionsLink: String, dummyErrors: Seq[ValidationErrorForRendering])(implicit request: RequiredSchemeDataRequest[_], messages: Messages)
+@(returnToFileUploadURL: String, fileDownloadInstructionsLink: String, dummyErrors: Seq[ValidationErrorForRendering], fileDownloadTemplateLink: String)(implicit request: RequiredSchemeDataRequest[_], messages: Messages)
 
 @layout(pageTitle = titleNoForm(messages("fileupload.invalid.title"))) {
 
  <h1 class="govuk-heading-xl">@messages("fileupload.invalid.heading")</h1>
-
- <p class="govuk-body">@messages("fileupload.invalid.p1")
-     <a href="@fileDownloadInstructionsLink" class="govuk-link">@messages("fileupload.invalid.download.instructions.link")</a>
+ <p class="govuk-body">@messages("fileupload.invalid.p1")</p>
+ <p class="govuk-body">
+     <a href="@fileDownloadTemplateLink" class="govuk-link">@messages("fileupload.invalid.download.template.link")</a>,
      @messages("fileupload.invalid.subheading.p2")
+     <a href="@fileDownloadInstructionsLink" class="govuk-link">@messages("fileupload.invalid.download.instructions.link")</a>.
  </p>
 
 @govukTable(

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1617,9 +1617,10 @@ fileUploadSuccess.p = {0} was uploaded successfully and the charge was added to 
 
 fileupload.invalid.title = There is a problem with your file
 fileupload.invalid.heading = There is a problem with your file
-fileupload.invalid.p1 = Correct the following errors and upload it again, or upload a different file.
-fileupload.invalid.download.instructions.link = Download the instructions for the format of your files
-fileupload.invalid.subheading.p2 = for more information.
+fileupload.invalid.p1 = Correct the following errors and upload it again, or try a different file.
+fileupload.invalid.download.instructions.link = instructions for guidance on how to complete it
+fileupload.invalid.download.template.link = Download the latest file
+fileupload.invalid.subheading.p2 = or the
 fileupload.invalid.h1 = Problems with your file
 fileupload.invalid.item1 = Cell
 fileupload.invalid.item2 = Error

--- a/test/controllers/fileUpload/ValidationErrorsAllControllerSpec.scala
+++ b/test/controllers/fileUpload/ValidationErrorsAllControllerSpec.scala
@@ -67,6 +67,7 @@ class ValidationErrorsAllControllerSpec extends SpecBase with BeforeAndAfterEach
   private def returnUrl(eventType: EventType) = s"/manage-pension-scheme-event-report/report/event-${eventType.toString}-upload"
 
   private def fileDownloadInstructionLink(eventType: EventType) = s"/manage-pension-scheme-event-report/event-${eventType.toString}-upload-format-instructions"
+  private def fileDownloadTemplateLink(eventType: EventType) = s"/manage-pension-scheme-event-report/event-${eventType.toString}-bulk-upload-template"
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -94,7 +95,7 @@ class ValidationErrorsAllControllerSpec extends SpecBase with BeforeAndAfterEach
         )
         status(result) mustEqual OK
         contentAsString(result) mustEqual view(returnUrl(eventType),
-          fileDownloadInstructionLink(eventType), dummyErrors)(request, messages(application)).toString
+          fileDownloadInstructionLink(eventType), dummyErrors, fileDownloadTemplateLink(eventType))(request, messages(application)).toString
       }
     }
   }


### PR DESCRIPTION
- In the event that a valid but blank template is uploaded, we display specific content that "No data has been added to the file"
- Minor tweaks to links and content present on this error page