### PR TITLE
Pods 8839

### DIFF
--- a/app/pages/event24/MarginalRatePage.scala
+++ b/app/pages/event24/MarginalRatePage.scala
@@ -22,7 +22,7 @@ import models.{Index, UserAnswers}
 import pages.common.MembersPage
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
-import pages.{Page, QuestionPage, Waypoints}
+import pages.{EmptyWaypoints, NonEmptyWaypoints, Page, QuestionPage, Waypoints}
 
 case class MarginalRatePage(index: Index) extends QuestionPage[Boolean] {
 
@@ -36,6 +36,19 @@ case class MarginalRatePage(index: Index) extends QuestionPage[Boolean] {
       case true  => EmployerPayeReferencePage(index)
       case false => Event24CheckYourAnswersPage(index)
     }.orRecover
+  }
+
+  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, originalAnswers: UserAnswers, updatedAnswers: UserAnswers): Page = {
+    val originalOptionSelected = originalAnswers.get(this)
+    val updatedOptionSelected = updatedAnswers.get(this)
+    val answerIsChanged = originalOptionSelected != updatedOptionSelected
+
+    if (answerIsChanged) {
+      nextPageNormalMode(EmptyWaypoints, updatedAnswers)
+    }
+    else {
+      Event24CheckYourAnswersPage(index)
+    }
   }
 }
 

--- a/app/pages/event24/MarginalRatePage.scala
+++ b/app/pages/event24/MarginalRatePage.scala
@@ -24,6 +24,8 @@ import play.api.libs.json.JsPath
 import play.api.mvc.Call
 import pages.{EmptyWaypoints, NonEmptyWaypoints, Page, QuestionPage, Waypoints}
 
+import scala.util.{Success, Try}
+
 case class MarginalRatePage(index: Index) extends QuestionPage[Boolean] {
 
   override def path: JsPath = MembersPage(EventType.Event24)(index) \ MarginalRatePage.toString
@@ -38,17 +40,24 @@ case class MarginalRatePage(index: Index) extends QuestionPage[Boolean] {
     }.orRecover
   }
 
+  override def cleanupBeforeSettingValue(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] = {
+    value match {
+      case Some(false) =>
+        Success(userAnswers
+          .remove(EmployerPayeReferencePage(index))
+          .getOrElse(userAnswers)
+        )
+      case _ => Success(userAnswers)
+    }
+  }
+
   override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, originalAnswers: UserAnswers, updatedAnswers: UserAnswers): Page = {
     val originalOptionSelected = originalAnswers.get(this)
     val updatedOptionSelected = updatedAnswers.get(this)
     val answerIsChanged = originalOptionSelected != updatedOptionSelected
 
-    if (answerIsChanged) {
-      nextPageNormalMode(EmptyWaypoints, updatedAnswers)
-    }
-    else {
-      Event24CheckYourAnswersPage(index)
-    }
+    if (answerIsChanged) { nextPageNormalMode(EmptyWaypoints, originalAnswers, updatedAnswers) }
+    else { Event24CheckYourAnswersPage(index) }
   }
 }
 

--- a/app/pages/event24/OverAllowanceAndDeathBenefitPage.scala
+++ b/app/pages/event24/OverAllowanceAndDeathBenefitPage.scala
@@ -22,7 +22,7 @@ import models.{Index, UserAnswers}
 import pages.common.MembersPage
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
-import pages.{Page, QuestionPage, Waypoints}
+import pages.{EmptyWaypoints, NonEmptyWaypoints, Page, QuestionPage, Waypoints}
 
 case class OverAllowanceAndDeathBenefitPage(index: Index) extends QuestionPage[Boolean] {
 
@@ -36,6 +36,19 @@ case class OverAllowanceAndDeathBenefitPage(index: Index) extends QuestionPage[B
       case true  => MarginalRatePage(index)
       case false => Event24CheckYourAnswersPage(index)
     }.orRecover
+  }
+
+  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, originalAnswers: UserAnswers, updatedAnswers: UserAnswers): Page = {
+    val originalOptionSelected = originalAnswers.get(this)
+    val updatedOptionSelected = updatedAnswers.get(this)
+    val answerIsChanged = originalOptionSelected != updatedOptionSelected
+
+    if (answerIsChanged) {
+      nextPageNormalMode(EmptyWaypoints, updatedAnswers)
+    }
+    else {
+      Event24CheckYourAnswersPage(index)
+    }
   }
 }
 

--- a/app/pages/event24/OverAllowancePage.scala
+++ b/app/pages/event24/OverAllowancePage.scala
@@ -22,7 +22,7 @@ import models.{Index, UserAnswers}
 import pages.common.MembersPage
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
-import pages.{Page, QuestionPage, Waypoints}
+import pages.{EmptyWaypoints, NonEmptyWaypoints, Page, QuestionPage, Waypoints}
 
 case class OverAllowancePage(index: Index) extends QuestionPage[Boolean] {
 
@@ -38,6 +38,19 @@ case class OverAllowancePage(index: Index) extends QuestionPage[Boolean] {
       case true  => MarginalRatePage(index)
       case false => OverAllowanceAndDeathBenefitPage(index)
     }.orRecover
+  }
+
+  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, originalAnswers: UserAnswers, updatedAnswers: UserAnswers): Page = {
+    val originalOptionSelected = originalAnswers.get(this)
+    val updatedOptionSelected = updatedAnswers.get(this)
+    val answerIsChanged = originalOptionSelected != updatedOptionSelected
+
+    if (answerIsChanged) {
+      nextPageNormalMode(EmptyWaypoints, updatedAnswers)
+    }
+    else {
+      Event24CheckYourAnswersPage(index)
+    }
   }
 }
 

--- a/app/pages/event24/OverAllowancePage.scala
+++ b/app/pages/event24/OverAllowancePage.scala
@@ -24,6 +24,8 @@ import play.api.libs.json.JsPath
 import play.api.mvc.Call
 import pages.{EmptyWaypoints, NonEmptyWaypoints, Page, QuestionPage, Waypoints}
 
+import scala.util.{Success, Try}
+
 case class OverAllowancePage(index: Index) extends QuestionPage[Boolean] {
 
   override def path: JsPath = MembersPage(EventType.Event24)(index) \ OverAllowancePage.toString
@@ -40,17 +42,24 @@ case class OverAllowancePage(index: Index) extends QuestionPage[Boolean] {
     }.orRecover
   }
 
+  override def cleanupBeforeSettingValue(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] = {
+    value match {
+      case Some(true) =>
+        Success(userAnswers
+          .remove(OverAllowanceAndDeathBenefitPage(index))
+          .getOrElse(userAnswers)
+        )
+      case _ => Success(userAnswers)
+    }
+  }
+
   override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, originalAnswers: UserAnswers, updatedAnswers: UserAnswers): Page = {
     val originalOptionSelected = originalAnswers.get(this)
     val updatedOptionSelected = updatedAnswers.get(this)
     val answerIsChanged = originalOptionSelected != updatedOptionSelected
 
-    if (answerIsChanged) {
-      nextPageNormalMode(EmptyWaypoints, updatedAnswers)
-    }
-    else {
-      Event24CheckYourAnswersPage(index)
-    }
+    if (answerIsChanged) { nextPageNormalMode(EmptyWaypoints, originalAnswers, updatedAnswers) }
+    else { Event24CheckYourAnswersPage(index) }
   }
 }
 

--- a/app/pages/event24/TypeOfProtectionPage.scala
+++ b/app/pages/event24/TypeOfProtectionPage.scala
@@ -21,7 +21,7 @@ import models.{Index, UserAnswers}
 import models.event24.TypeOfProtectionSelection
 import models.event24.TypeOfProtectionSelection.SchemeSpecific
 import pages.common.MembersPage
-import pages.{Page, QuestionPage, Waypoints}
+import pages.{EmptyWaypoints, NonEmptyWaypoints, Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -37,6 +37,19 @@ case class TypeOfProtectionPage(index: Index) extends QuestionPage[TypeOfProtect
       case SchemeSpecific => OverAllowancePage(index)
       case _ => TypeOfProtectionReferencePage(index)
     }.orRecover
+  }
+
+  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, originalAnswers: UserAnswers, updatedAnswers: UserAnswers): Page = {
+    val originalOptionSelected = originalAnswers.get(this)
+    val updatedOptionSelected = updatedAnswers.get(this)
+    val answerIsChanged = originalOptionSelected != updatedOptionSelected
+
+    if (answerIsChanged) {
+      nextPageNormalMode(EmptyWaypoints, updatedAnswers)
+    }
+    else {
+      Event24CheckYourAnswersPage(index)
+    }
   }
 }
 

--- a/app/pages/event24/TypeOfProtectionReferencePage.scala
+++ b/app/pages/event24/TypeOfProtectionReferencePage.scala
@@ -19,7 +19,7 @@ package pages.event24
 import models.UserAnswers
 import models.enumeration.EventType
 import pages.common.MembersPage
-import pages.{Page, QuestionPage, Waypoints}
+import pages.{EmptyWaypoints, NonEmptyWaypoints, Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -32,6 +32,19 @@ case class TypeOfProtectionReferencePage(index: Int) extends QuestionPage[String
 
   override protected def nextPageNormalMode(waypoints: Waypoints, answers: UserAnswers): Page =
     OverAllowancePage(index)
+
+  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, originalAnswers: UserAnswers, updatedAnswers: UserAnswers): Page = {
+    val originalOptionSelected = originalAnswers.get(this)
+    val updatedOptionSelected = updatedAnswers.get(this)
+    val answerIsChanged = originalOptionSelected != updatedOptionSelected
+
+    if (answerIsChanged) {
+      nextPageNormalMode(EmptyWaypoints, updatedAnswers)
+    }
+    else {
+      Event24CheckYourAnswersPage(index)
+    }
+  }
 }
 
 object TypeOfProtectionReferencePage {

--- a/app/pages/event24/ValidProtectionPage.scala
+++ b/app/pages/event24/ValidProtectionPage.scala
@@ -41,8 +41,8 @@ case class ValidProtectionPage(index: Index) extends QuestionPage[Boolean] {
   }
 
   override def cleanupBeforeSettingValue(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] = {
-    (userAnswers.get(this), value) match {
-      case (Some(true), Some(false)) =>
+    value match {
+      case Some(false) =>
         Success(userAnswers
           .remove(TypeOfProtectionPage(index))
           .flatMap(_.remove(TypeOfProtectionReferencePage(index)))
@@ -57,12 +57,8 @@ case class ValidProtectionPage(index: Index) extends QuestionPage[Boolean] {
     val updatedOptionSelected = updatedAnswers.get(this)
     val answerIsChanged = originalOptionSelected != updatedOptionSelected
 
-    if (answerIsChanged) {
-      nextPageNormalMode(EmptyWaypoints, originalAnswers, updatedAnswers)
-    }
-    else {
-      Event24CheckYourAnswersPage(index)
-    }
+    if (answerIsChanged) { nextPageNormalMode(EmptyWaypoints, originalAnswers, updatedAnswers) }
+    else { Event24CheckYourAnswersPage(index) }
   }
 }
 

--- a/app/pages/event24/ValidProtectionPage.scala
+++ b/app/pages/event24/ValidProtectionPage.scala
@@ -20,9 +20,11 @@ import controllers.event24.routes
 import models.enumeration.EventType
 import models.{Index, UserAnswers}
 import pages.common.MembersPage
+import pages.{EmptyWaypoints, NonEmptyWaypoints, Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
-import pages.{EmptyWaypoints, NonEmptyWaypoints, Page, QuestionPage, Waypoints}
+
+import scala.util.{Success, Try}
 
 case class ValidProtectionPage(index: Index) extends QuestionPage[Boolean] {
 
@@ -38,13 +40,29 @@ case class ValidProtectionPage(index: Index) extends QuestionPage[Boolean] {
     }.orRecover
   }
 
+  override def cleanupBeforeSettingValue(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] = {
+    (userAnswers.get(this), value) match {
+      case (Some(true), Some(false)) =>
+        Success(userAnswers
+          .remove(TypeOfProtectionPage(index))
+          .flatMap(_.remove(TypeOfProtectionReferencePage(index)))
+          .getOrElse(userAnswers)
+        )
+      case _ => Success(userAnswers)
+    }
+  }
+
   override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, originalAnswers: UserAnswers, updatedAnswers: UserAnswers): Page = {
     val originalOptionSelected = originalAnswers.get(this)
     val updatedOptionSelected = updatedAnswers.get(this)
     val answerIsChanged = originalOptionSelected != updatedOptionSelected
 
-    if (answerIsChanged) { nextPageNormalMode(EmptyWaypoints, updatedAnswers) }
-    else { Event24CheckYourAnswersPage(index) }
+    if (answerIsChanged) {
+      nextPageNormalMode(EmptyWaypoints, originalAnswers, updatedAnswers)
+    }
+    else {
+      Event24CheckYourAnswersPage(index)
+    }
   }
 }
 

--- a/app/pages/event24/ValidProtectionPage.scala
+++ b/app/pages/event24/ValidProtectionPage.scala
@@ -22,7 +22,7 @@ import models.{Index, UserAnswers}
 import pages.common.MembersPage
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
-import pages.{Page, QuestionPage, Waypoints}
+import pages.{EmptyWaypoints, NonEmptyWaypoints, Page, QuestionPage, Waypoints}
 
 case class ValidProtectionPage(index: Index) extends QuestionPage[Boolean] {
 
@@ -33,9 +33,18 @@ case class ValidProtectionPage(index: Index) extends QuestionPage[Boolean] {
 
   override protected def nextPageNormalMode(waypoints: Waypoints, answers: UserAnswers): Page = {
     answers.get(this).map {
-      case true  => TypeOfProtectionPage(index)
+      case true => TypeOfProtectionPage(index)
       case false => OverAllowancePage(index)
     }.orRecover
+  }
+
+  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, originalAnswers: UserAnswers, updatedAnswers: UserAnswers): Page = {
+    val originalOptionSelected = originalAnswers.get(this)
+    val updatedOptionSelected = updatedAnswers.get(this)
+    val answerIsChanged = originalOptionSelected != updatedOptionSelected
+
+    if (answerIsChanged) { nextPageNormalMode(EmptyWaypoints, updatedAnswers) }
+    else { Event24CheckYourAnswersPage(index) }
   }
 }
 


### PR DESCRIPTION
Check Your Answers (CYA) navigation is updated:
- For answers changed prior to the 'Does member hold protection' question, routing will always return the user to CYA page.
- For answers changed on or after the 'Does member hold protection' question, routing will take the user through the next set of required questions that depend on the changed answer.