### PR TITLE
PODS-8823: Added no new lines string generator

### DIFF
--- a/test-utils/generators/Generators.scala
+++ b/test-utils/generators/Generators.scala
@@ -113,6 +113,9 @@ trait Generators extends PageGenerators with ModelGenerators with UserAnswersEnt
   def nonEmptyString: Gen[String] =
     arbitrary[String] suchThat (_.nonEmpty)
 
+  def nonEmptyStringNoNewlines: Gen[String] =
+    arbitrary[String].filter(s => s.nonEmpty && !s.contains("\n")).map(_.replace("\n", ""))
+
   def stringsWithMaxLength(maxLength: Int): Gen[String] =
     for {
       length <- choose(1, maxLength)
@@ -132,6 +135,9 @@ trait Generators extends PageGenerators with ModelGenerators with UserAnswersEnt
 
   def stringsExceptSpecificValues(excluded: Seq[String]): Gen[String] =
     nonEmptyString suchThat (!excluded.contains(_))
+
+  def stringsExceptSpecificValuesAndNoNewlines(excluded: Seq[String]): Gen[String] =
+    nonEmptyStringNoNewlines suchThat (!excluded.contains(_))
 
   def oneOf[T](xs: Seq[Gen[T]]): Gen[T] =
     if (xs.isEmpty) {

--- a/test/forms/behaviours/OptionFieldBehaviours.scala
+++ b/test/forms/behaviours/OptionFieldBehaviours.scala
@@ -37,7 +37,10 @@ class OptionFieldBehaviours extends FieldBehaviours {
 
     "not bind invalid values" in {
 
-      val generator = stringsExceptSpecificValues(validValues.map(_.toString))
+      val generator = validValues.headOption match {
+        case Some(_: String) => stringsExceptSpecificValues(validValues.map(_.toString))
+        case _ => stringsExceptSpecificValuesAndNoNewlines(validValues.map(_.toString))
+      }
 
       forAll(generator -> "invalidValue") {
         value =>


### PR DESCRIPTION
Code:
- In tests for `...FormProviderSpec`, the behaviour of the "not bind invalid values" has been split for `Form[String]` and `Form[_]`
- For `Form[_]`, when we generate invalid values, we do not allow these values to be the newline character `\n`. This was intermittently breaking the unit tests and is not possible in the FE as the input will be of a different type (radio buttons, currency input, etc.).
- For `Form[String]`, we still allow `\n` to be generated and used in the tests, as the FE should be handling and protecting against this kind of input.
- If in the future, a `Form[String]` test fails for newline character, it's a sign that that input should be amended to protect against that input. 