### PR TITLE
Pods 8909 - Removed NINO uniqueness constraint on member based events

### DIFF
--- a/app/forms/common/MembersDetailsFormProvider.scala
+++ b/app/forms/common/MembersDetailsFormProvider.scala
@@ -27,7 +27,6 @@ import play.api.data.{Form, Mapping}
 
 import scala.collection.immutable.HashSet
 
-
 class MembersDetailsFormProvider {
 
   def apply(eventType: EventType, memberNinos: HashSet[String], memberPageNo: Int = 0): Form[MembersDetails] = {
@@ -42,7 +41,7 @@ class MembersDetailsFormProvider {
       mapping(
         nameMapping(firstName, detailsType),
         nameMapping(lastName, detailsType),
-        ninoMapping(detailsType, memberNinos)
+        ninoMapping(detailsType)
       )(MembersDetails.apply)(MembersDetails.unapply)
     )
   }
@@ -57,9 +56,9 @@ object MembersDetailsFormProvider extends Mappings with Transforms {
     field -> text(s"$detailsType.error.$field.required")
       .verifying(nameIsValid(field, detailsType))
 
-  private val ninoMapping: (String, HashSet[String]) => (String, Mapping[String]) = (detailsType: String, memberNinos: HashSet[String]) =>
+  private val ninoMapping: String => (String, Mapping[String]) = (detailsType: String) =>
     nino -> text(s"$detailsType.error.$nino.required").transform(noSpaceWithUpperCaseTransform, noTransform)
-      .verifying(ninoIsValid(detailsType, memberNinos))
+      .verifying(ninoIsValid(detailsType))
 
   private val nameIsValid: (String, String) => Constraint[String] = (nameField: String, detailsType: String) =>
     firstError(
@@ -67,9 +66,5 @@ object MembersDetailsFormProvider extends Mappings with Transforms {
       regexp(regexName, s"$detailsType.error.$nameField.invalid")
     )
 
-  private val ninoIsValid: (String, HashSet[String]) => Constraint[String] = (detailsType: String, memberNinos: HashSet[String]) =>
-    firstError(
-      validNino,
-      nonUniqueNino(s"$detailsType.error.nino.notUnique", memberNinos)
-    )
+  private val ninoIsValid: String => Constraint[String] = (_: String) => validNino
 }

--- a/app/forms/common/MembersDetailsFormProvider.scala
+++ b/app/forms/common/MembersDetailsFormProvider.scala
@@ -25,11 +25,9 @@ import play.api.data.Forms.mapping
 import play.api.data.validation.Constraint
 import play.api.data.{Form, Mapping}
 
-import scala.collection.immutable.HashSet
-
 class MembersDetailsFormProvider {
 
-  def apply(eventType: EventType, memberNinos: HashSet[String], memberPageNo: Int = 0): Form[MembersDetails] = {
+  def apply(eventType: EventType, memberPageNo: Int = 0): Form[MembersDetails] = {
 
     val detailsType = (eventType, memberPageNo) match {
       case (Event2, 1) => "deceasedMembersDetails"

--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -21,7 +21,6 @@ import uk.gov.hmrc.domain.Nino
 import utils.CountryOptions
 
 import java.time.LocalDate
-import scala.collection.immutable.HashSet
 import scala.language.implicitConversions
 
 trait Constraints {
@@ -30,7 +29,6 @@ trait Constraints {
   val regexPersonOrOrgName = """^[a-zA-Z &`\'\.^\\]{0,160}$"""
   val regexMemberRecipientName = """^[a-zA-Z &`\\\-\'\.^]{0,150}$"""
   val regexPostcode = """^[A-Z]{1,2}[0-9][0-9A-Z]?\s?[0-9][A-Z]{2}$"""
-  val regexPostCodeNonUk = """^([0-9]+-)*[0-9]+$"""
   val regexAddressLine = """^[A-Za-z0-9 &!'‘’(),./\u2014\u2013\u2010\u002d]{1,35}$"""
   val regexSafeText = """^[a-zA-Z0-9\u00C0-\u00FF !#$%&'‘’"“”«»()*+,./:;=?@\\\[\]|~£€¥\u005C\u2014\u2013\u2010\u005F\u005E\u0060\u002d]{1,160}$"""
   val regexCrn = "^[A-Za-z0-9 -]{7,8}$"
@@ -42,8 +40,6 @@ trait Constraints {
   val protectionReferenceRegex = "^[A-Za-z0-9]{1,15}$"
 
   protected def postCode(errorKey: String): Constraint[String] = regexp(regexPostcode, errorKey)
-
-  protected def postCodeNonUk(errorKey: String): Constraint[String] = regexp(regexPostCodeNonUk, errorKey)
 
   protected def addressLine(errorKey: String): Constraint[String] = regexp(regexAddressLine, errorKey)
 
@@ -188,13 +184,6 @@ trait Constraints {
     conditionsAndErrors.collectFirst {
       case (condition, error) if condition(input) => Invalid(error)
     }.getOrElse(Valid)
-  }
-
-  protected def nonUniqueNino(notUniqueKey: String, ninos: HashSet[String]): Constraint[String] = {
-    Constraint {
-      case nino if ninos.contains(nino) => Invalid(notUniqueKey)
-      case _ => Valid
-    }
   }
 
   protected def yearHas4Digits(errorKey: String): Constraint[LocalDate] =

--- a/app/services/fileUpload/Event1Validator.scala
+++ b/app/services/fileUpload/Event1Validator.scala
@@ -48,8 +48,6 @@ import play.api.i18n.Messages
 import play.api.libs.json.JsString
 import services.fileUpload.Validator.Result
 
-import scala.collection.immutable.HashSet
-
 class Event1Validator @Inject()(
                                  whoReceivedUnauthPaymentFormProvider: WhoReceivedUnauthPaymentFormProvider,
                                  membersDetailsFormProvider: MembersDetailsFormProvider,
@@ -344,8 +342,7 @@ class Event1Validator @Inject()(
 
   override protected def validateFields(index: Int,
                                         columns: Seq[String],
-                                        taxYear: Int,
-                                        memberNinos: HashSet[String])
+                                        taxYear: Int)
                                        (implicit messages: Messages): Result = {
 
     val a = resultFromFormValidationResult[WhoReceivedUnauthPayment](
@@ -357,7 +354,7 @@ class Event1Validator @Inject()(
       case Result(_, Valid(seqCommitItems)) =>
         seqCommitItems.headOption match {
           case Some(ci) => ci.value.as[JsString].value match {
-            case "member" => memberValidation(a, index, columns, taxYear, memberNinos)
+            case "member" => memberValidation(a, index, columns, taxYear)
             case "employer" => employerValidation(a, index, columns, taxYear)
           }
           case _ => throw new RuntimeException("Something went wrong: member or employer not entered/found")
@@ -508,11 +505,10 @@ class Event1Validator @Inject()(
   private def memberValidation(memberOrEmployerResult: Result,
                                index: Int,
                                columns: Seq[String],
-                               taxYear: Int,
-                               memberNinos: HashSet[String])
+                               taxYear: Int)
                               (implicit messages: Messages): Result = {
     val b = resultFromFormValidationResultForMembersDetails(
-      memberDetailsValidation(index, columns, membersDetailsFormProvider(Event1, memberNinos, index)),
+      memberDetailsValidation(index, columns, membersDetailsFormProvider(Event1, index)),
       createCommitItem(index, MembersDetailsPage.apply(Event1, _))
     )
 

--- a/app/services/fileUpload/Event22Validator.scala
+++ b/app/services/fileUpload/Event22Validator.scala
@@ -32,8 +32,6 @@ import play.api.data.Form
 import play.api.i18n.Messages
 import services.fileUpload.Validator.Result
 
-import scala.collection.immutable.HashSet
-
 class Event22Validator @Inject()(
                                   membersDetailsFormProvider: MembersDetailsFormProvider,
                                   chooseTaxYearFormProvider: ChooseTaxYearFormProvider,
@@ -81,11 +79,10 @@ class Event22Validator @Inject()(
 
   override protected def validateFields(index: Int,
                                         columns: Seq[String],
-                                        taxYear: Int,
-                                        memberNinos: HashSet[String])
+                                        taxYear: Int)
                                        (implicit messages: Messages): Result = {
     val a = resultFromFormValidationResultForMembersDetails(
-      memberDetailsValidation(index, columns, membersDetailsFormProvider(Event22, memberNinos, index)),
+      memberDetailsValidation(index, columns, membersDetailsFormProvider(Event22, index)),
       createCommitItem(index, MembersDetailsPage.apply(Event22, _))
     )
     val b = resultFromFormValidationResult[ChooseTaxYear](

--- a/app/services/fileUpload/Event23Validator.scala
+++ b/app/services/fileUpload/Event23Validator.scala
@@ -32,8 +32,6 @@ import play.api.data.Form
 import play.api.i18n.Messages
 import services.fileUpload.Validator.Result
 
-import scala.collection.immutable.HashSet
-
 class Event23Validator @Inject()(
                                   membersDetailsFormProvider: MembersDetailsFormProvider,
                                   chooseTaxYearFormProvider: ChooseTaxYearFormProvider,
@@ -81,11 +79,10 @@ class Event23Validator @Inject()(
 
   override protected def validateFields(index: Int,
                                         columns: Seq[String],
-                                        taxYear: Int,
-                                        memberNinos: HashSet[String])
+                                        taxYear: Int)
                                        (implicit messages: Messages): Result = {
     val a = resultFromFormValidationResultForMembersDetails(
-      memberDetailsValidation(index, columns, membersDetailsFormProvider(Event23, memberNinos, index)),
+      memberDetailsValidation(index, columns, membersDetailsFormProvider(Event23, index)),
       createCommitItem(index, MembersDetailsPage.apply(Event23, _))
     )
 

--- a/app/services/fileUpload/Event24Validator.scala
+++ b/app/services/fileUpload/Event24Validator.scala
@@ -36,7 +36,6 @@ import services.fileUpload.Validator.Result
 
 import java.time.LocalDate
 import javax.inject.Inject
-import scala.collection.immutable.HashSet
 
 class Event24Validator @Inject()(
                                  membersDetailsFormProvider: MembersDetailsFormProvider,
@@ -222,11 +221,10 @@ class Event24Validator @Inject()(
 
   override protected def validateFields(index: Int,
                                         columns: Seq[String],
-                                        taxYear: Int,
-                                        memberNinos: HashSet[String])
+                                        taxYear: Int)
                                        (implicit messages: Messages): Result = {
     val a = resultFromFormValidationResultForMembersDetails(
-      memberDetailsValidation(index, columns, membersDetailsFormProvider(Event24, memberNinos, index)),
+      memberDetailsValidation(index, columns, membersDetailsFormProvider(Event24, index)),
       createCommitItem(index, MembersDetailsPage.apply(Event24, _))
     )
 

--- a/app/services/fileUpload/Event6Validator.scala
+++ b/app/services/fileUpload/Event6Validator.scala
@@ -35,7 +35,6 @@ import play.api.i18n.Messages
 import services.fileUpload.Validator.Result
 
 import java.time.LocalDate
-import scala.collection.immutable.HashSet
 
 class Event6Validator @Inject()(
                                  membersDetailsFormProvider: MembersDetailsFormProvider,
@@ -125,12 +124,11 @@ class Event6Validator @Inject()(
 
   override protected def validateFields(index: Int,
                                         columns: Seq[String],
-                                        taxYear: Int,
-                                        memberNinos: HashSet[String])
+                                        taxYear: Int)
                                        (implicit messages: Messages): Result = {
 
     val a = resultFromFormValidationResultForMembersDetails(
-      memberDetailsValidation(index, columns, membersDetailsFormProvider(Event6, memberNinos, index)),
+      memberDetailsValidation(index, columns, membersDetailsFormProvider(Event6, index)),
       createCommitItem(index, MembersDetailsPage.apply(Event6, _))
     )
 

--- a/app/services/fileUpload/Validator.scala
+++ b/app/services/fileUpload/Validator.scala
@@ -55,7 +55,7 @@ object Validator {
 
   val FileLevelValidationErrorTypeHeaderInvalidOrFileEmpty: ValidationError = ValidationError(0, 0, HeaderInvalidOrFileIsEmpty, EMPTY)
 
-  val FileLevelValidationErrorTypeNoDataRowsProvided: ValidationError = ValidationError(0, 0, NoDataRowsProvided, EMPTY)
+  private val FileLevelValidationErrorTypeNoDataRowsProvided: ValidationError = ValidationError(0, 0, NoDataRowsProvided, EMPTY)
 }
 
 trait Validator {
@@ -103,14 +103,13 @@ trait Validator {
     rows.zipWithIndex.foldLeft[Result](monoidResult.empty) {
       case (acc, Tuple2(_, 0)) => acc
       case (acc, Tuple2(row, index)) =>
-        Seq(acc, validateFields(index, row.toIndexedSeq, taxYear, acc.memberNinos)).combineAll
+        Seq(acc, validateFields(index, row.toIndexedSeq, taxYear)).combineAll
     }
   }
 
   protected def validateFields(index: Int,
                                columns: Seq[String],
-                               taxYear: Int,
-                               memberNinos: HashSet[String]
+                               taxYear: Int
                               )(implicit messages: Messages): Result
 
   protected def memberDetailsValidation(index: Int, columns: Seq[String],
@@ -189,13 +188,6 @@ trait Validator {
       case _ => ParsedAddress(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY)
     }
   }
-
-  protected final def stringToBoolean(s: String): String =
-    s.toLowerCase match {
-      case "yes" => "true"
-      case "no" => "false"
-      case l => l
-    }
 }
 
 case class ValidationError(row: Int, col: Int, error: String, columnName: String = EMPTY, args: Seq[Any] = Nil)

--- a/test/controllers/common/MembersDetailsControllerSpec.scala
+++ b/test/controllers/common/MembersDetailsControllerSpec.scala
@@ -52,7 +52,7 @@ class MembersDetailsControllerSpec extends SpecBase with BeforeAndAfterEach with
     bind[UserAnswersCacheConnector].toInstance(mockUserAnswersCacheConnector)
   )
 
-  private def form(eventType: EventType, members: HashSet[String]): Form[MembersDetails] = formProvider(eventType, members)
+  private def form(eventType: EventType): Form[MembersDetails] = formProvider(eventType)
 
   private def getRoute(eventType: EventType): String = routes.MembersDetailsController.onPageLoad(waypoints, eventType, Index(0), memberPageNo = 0).url
 
@@ -89,7 +89,7 @@ class MembersDetailsControllerSpec extends SpecBase with BeforeAndAfterEach with
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view.render(
-          form(eventType, HashSet()),
+          form(eventType),
           waypoints,
           eventType,
           memberPageNo = 0,
@@ -110,7 +110,7 @@ class MembersDetailsControllerSpec extends SpecBase with BeforeAndAfterEach with
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view.render(
-          form(eventType, HashSet()).fill(validValue),
+          form(eventType).fill(validValue),
           waypoints,
           eventType,
           memberPageNo = 0,
@@ -151,7 +151,7 @@ class MembersDetailsControllerSpec extends SpecBase with BeforeAndAfterEach with
       running(application) {
         val request = FakeRequest(POST, postRoute(eventType)).withFormUrlEncodedBody(("firstName", "%"), ("lastName", ""), ("nino", "abc"))
         val view = application.injector.instanceOf[MembersDetailsView]
-        val boundForm = form(eventType, HashSet()).bind(Map("firstName" -> "%", "lastName" -> "", "nino" -> "abc"))
+        val boundForm = form(eventType).bind(Map("firstName" -> "%", "lastName" -> "", "nino" -> "abc"))
         val result = route(application, request).value
 
         status(result) mustEqual BAD_REQUEST
@@ -181,7 +181,7 @@ class MembersDetailsControllerSpec extends SpecBase with BeforeAndAfterEach with
           FakeRequest(POST, postRoute(eventType)).withFormUrlEncodedBody(("firstName", "John"), ("lastName", ""), ("nino", nino))
 
         val view = application.injector.instanceOf[MembersDetailsView]
-        val boundForm = form(eventType, HashSet()).bind(Map("firstName" -> "John", "lastName" -> "", "nino" -> nino))
+        val boundForm = form(eventType).bind(Map("firstName" -> "John", "lastName" -> "", "nino" -> nino))
         val result = route(application, request).value
 
         status(result) mustEqual BAD_REQUEST

--- a/test/forms/common/MembersDetailsFormProviderSpec.scala
+++ b/test/forms/common/MembersDetailsFormProviderSpec.scala
@@ -29,10 +29,10 @@ import scala.util.Random
 
 class MembersDetailsFormProviderSpec extends StringFieldBehaviours with Constraints {
 
-  private val memberNinos: HashSet[String] = HashSet("CS121212C", "CS121212B")
   val listOfEvents: Seq[EventType] = Seq(Event1, Event22, Event23)
   val event: EventType = Random.shuffle(listOfEvents).head
   val form = new MembersDetailsFormProvider()(event, memberNinos)
+  private val memberNinos: HashSet[String] = HashSet("CS121212C", "CS121212B")
 
   ".firstName" - {
 
@@ -112,7 +112,6 @@ class MembersDetailsFormProviderSpec extends StringFieldBehaviours with Constrai
     val numbersKey = "genericNino.error.invalid.numbers"
     val suffixKey = "genericNino.error.invalid.suffix"
     val invalidKey = "genericNino.error.invalid"
-    val notUniqueKey = "membersDetails.error.nino.notUnique"
     val fieldName = "nino"
 
     Seq("aB020202A", "Ab020202A", "AB020202a", "AB020202A", "ab020202a").foreach { nino =>
@@ -140,22 +139,5 @@ class MembersDetailsFormProviderSpec extends StringFieldBehaviours with Constrai
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
-
-
-    Seq("CS121212C", "CS121212B").foreach { nino =>
-      s"fail to bind when NINO $nino is not unique" in {
-        val memberNinos: HashSet[String] = HashSet("CS121212C", "CS121212B")
-        val form = new MembersDetailsFormProvider()(event, memberNinos)
-        val result = form.bind(Map("firstName" -> "validFirstName", "lastName" -> "validLastName", "nino" -> nino))
-        result.errors mustBe Seq(FormError("nino", notUniqueKey))
-      }
-
-      s"successfully bind when NINO $nino is unique" in {
-        val memberNinos: HashSet[String] = HashSet("Ab020202A", "AB020202a")
-        val form = new MembersDetailsFormProvider()(event, memberNinos)
-        val result = form.bind(Map("firstName" -> "validFirstName", "lastName" -> "validLastName", "nino" -> nino))
-        result.errors mustBe Seq()
-      }
-    }
   }
 }

--- a/test/forms/common/MembersDetailsFormProviderSpec.scala
+++ b/test/forms/common/MembersDetailsFormProviderSpec.scala
@@ -24,15 +24,13 @@ import models.enumeration.EventType.{Event1, Event22, Event23}
 import play.api.data.FormError
 import wolfendale.scalacheck.regexp.RegexpGen
 
-import scala.collection.immutable.HashSet
 import scala.util.Random
 
 class MembersDetailsFormProviderSpec extends StringFieldBehaviours with Constraints {
 
   val listOfEvents: Seq[EventType] = Seq(Event1, Event22, Event23)
   val event: EventType = Random.shuffle(listOfEvents).head
-  val form = new MembersDetailsFormProvider()(event, memberNinos)
-  private val memberNinos: HashSet[String] = HashSet("CS121212C", "CS121212B")
+  val form = new MembersDetailsFormProvider()(event)
 
   ".firstName" - {
 

--- a/test/services/fileUpload/Event1ValidatorSpec.scala
+++ b/test/services/fileUpload/Event1ValidatorSpec.scala
@@ -311,23 +311,6 @@ class Event1ValidatorSpec extends SpecBase with Matchers with MockitoSugar with 
       ))
     }
 
-    "return validation errors when present for a duplicate nino (Member)" in {
-
-      DateHelper.setDate(Some(LocalDate.of(2022, 6, 1)))
-      val csvFile = CSVParser.split(
-        s"""$header
-                        member,Joe,Bloggs,AA234567D,YES,YES,YES,,,,BENEFIT,Description,,,,,,,,,,,,,1000.00,08/11/2022
-                        member,Joe,Bloggs,AA234567D,YES,YES,YES,,,,BENEFIT,Description,,,,,,,,,,,,,1000.00,08/11/2022"""
-
-      )
-      val ua = UserAnswers().setOrException(TaxYearPage, TaxYear("2022"), nonEventTypeData = true)
-
-      val result = validator.validate(csvFile, ua)
-      result mustBe Invalid(Seq(
-        ValidationError(2, 3, "membersDetails.error.nino.notUnique", "nino")
-      ))
-    }
-
     "return validation errors when present for the payment amount field (Member)" in {
       DateHelper.setDate(Some(LocalDate.of(2022, 6, 1)))
       val csvFile = CSVParser.split(

--- a/test/services/fileUpload/Event22ValidatorSpec.scala
+++ b/test/services/fileUpload/Event22ValidatorSpec.scala
@@ -127,8 +127,7 @@ class Event22ValidatorSpec extends SpecBase with Matchers with MockitoSugar with
         ValidationError(2, 1, "membersDetails.error.lastName.required", "lastName"),
         ValidationError(2, 2, "genericNino.error.invalid.length", "nino"),
         ValidationError(2, 3, "chooseTaxYear.event22.error.required", "taxYear", Seq("2013", "2023")),
-        ValidationError(2, 4, "totalPensionAmounts.value.error.nothingEntered", "totalAmounts"),
-        ValidationError(4, 2, "membersDetails.error.nino.notUnique", "nino")
+        ValidationError(2, 4, "totalPensionAmounts.value.error.nothingEntered", "totalAmounts")
       ))
     }
 

--- a/test/services/fileUpload/Event23ValidatorSpec.scala
+++ b/test/services/fileUpload/Event23ValidatorSpec.scala
@@ -100,8 +100,7 @@ class Event23ValidatorSpec extends SpecBase with Matchers with MockitoSugar with
         ValidationError(2, 1, "membersDetails.error.lastName.required", "lastName"),
         ValidationError(2, 2, "genericNino.error.invalid.length", "nino"),
         ValidationError(2, 3, "chooseTaxYear.event23.error.required", "taxYear", Seq("2013", "2023")),
-        ValidationError(2, 4, "totalPensionAmounts.value.error.nothingEntered", "totalAmounts"),
-        ValidationError(4, 2, "membersDetails.error.nino.notUnique", "nino")
+        ValidationError(2, 4, "totalPensionAmounts.value.error.nothingEntered", "totalAmounts")
       ))
     }
 

--- a/test/services/fileUpload/Event24ValidatorSpec.scala
+++ b/test/services/fileUpload/Event24ValidatorSpec.scala
@@ -81,19 +81,6 @@ class Event24ValidatorSpec extends SpecBase with Matchers with MockitoSugar with
         ValidationError(1, 3, "Date must be between 06 April 2023 and 05 April 2024", "crystallisedDate"),
       ))
     }
-    "return validation errors when present for a duplicate nino" in {
-      val csvFile = CSVParser.split(
-        s"""$header
-                        Jane,Doe,AB123456A,13/11/2023,ANN,123,YES,FIXED,abcdef123,NO,YES,YES,123/ABCDEF
-                        Jane,Doe,AB123456A,13/11/2023,ANN,123,YES,FIXED,abcdef123,NO,YES,YES,123/ABCDEF"""
-
-      )
-      val ua = UserAnswers().setOrException(TaxYearPage, TaxYear("2023"), nonEventTypeData = true)
-      val result = validator.validate(csvFile, ua)
-      result mustBe Invalid(Seq(
-        ValidationError(2, 2, "membersDetails.error.nino.notUnique", "nino")
-      ))
-    }
     "return validation errors if present" in {
       DateHelper.setDate(Some(LocalDate.of(2023, 6, 1)))
       val csvFile = CSVParser.split(

--- a/test/services/fileUpload/Event6ValidatorSpec.scala
+++ b/test/services/fileUpload/Event6ValidatorSpec.scala
@@ -103,8 +103,7 @@ class Event6ValidatorSpec extends SpecBase with Matchers with MockitoSugar with 
         ValidationError(1, 4, "inputProtectionType.error.required", "typeOfProtectionReference"),
         ValidationError(2, 2, "membersDetails.error.nino.required", "nino"),
         ValidationError(2, 3, "typeOfProtection.error.format", "typeOfProtection"),
-        ValidationError(2, 6, "Date must be between 06 April 2006 and 05 April 2024", "crystallisedDate"),
-        ValidationError(4, 2, "membersDetails.error.nino.notUnique", "nino")
+        ValidationError(2, 6, "Date must be between 06 April 2006 and 05 April 2024", "crystallisedDate")
       ))
     }
   }


### PR DESCRIPTION
- Now, several entries for the same NINO can be made in compiling event reports for the same event in the same tax year without triggering an error.